### PR TITLE
Version bump: fix warnings for unnecessary parentheses, Chrono::Date and Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Martin Holzhauer <martin@holzhauer.eu>"]
 edition = "2018"
 
 license = "MIT"
-license-file = "LICENSE"
 
 keywords = ["timew", "timewarrior"]
 categories = ["parsing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ license = "MIT"
 
 keywords = ["timew", "timewarrior"]
 categories = ["parsing"]
-maintenance = { status = "experimental" }
 
 description = "a simple library to read timewarrior data files"
+
+[badges]
+maintenance = { status = "experimental" }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libtimew"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Martin Holzhauer <martin@holzhauer.eu>"]
 edition = "2018"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use chrono::prelude::*;
 use std::str::FromStr;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct TimeWarriorLine {
     tw_type: String,
     from: DateTime<Utc>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,12 @@ impl TimeWarriorLine {
         self.tags.join(" ")
     }
 
+    //fix: use of deprecated struct `chrono::Date`: use `chrono::NaiveDate` instead
+    pub fn get_day_naive(&self) -> NaiveDate {
+        self.from.date_naive()
+    }
+
+    #[deprecated(since = "0.1.4", note = "please use `get_day_naive` instead")]
     pub fn get_day(&self) -> Date<Utc> {
         self.from.date()
     }
@@ -306,6 +312,24 @@ mod tests {
         let line = result.unwrap();
 
         assert_eq!(line.duration(), chrono::Duration::minutes(10));
+    }
+
+    #[test]
+    fn date_naive_is_correct() {
+        let result = TimeWarriorLine::from_str("inc 20001011T133055Z - 20001011T134055Z");
+        assert_eq!(
+            result.is_ok(),
+            true,
+            "parsed line is not a ok result {:?}",
+            result
+        );
+
+        let line = result.unwrap();
+
+        assert_eq!(
+            line.get_day_naive(),
+            chrono::NaiveDate::from_ymd_opt(2000, 10, 11).expect("Invalid date")
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl FromStr for TimeWarriorLine {
                         return Err(TimeWarriorLineError::NoDate());
                     }
                 };
-                (f)
+                f
             }
             _ => {
                 return Err(TimeWarriorLineError::NoDate());
@@ -88,13 +88,13 @@ impl FromStr for TimeWarriorLine {
                                 ));
                             }
                         };
-                        (f)
+                        f
                     }
                     None => {
                         return Err(TimeWarriorLineError::Generic("nope".to_owned()));
                     }
                 };
-                (utc)
+                utc
             }
             // no enddate and no tags
             None => {
@@ -155,7 +155,7 @@ fn parse_date(date_string: String) -> Option<DateTime<Utc>> {
         Ok(a) => Utc.from_local_datetime(&a.naive_local()).single(),
         Err(_) => None,
     };
-    (date)
+    date
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR is intended for maintenance as eliminates the currents compiler warnings.

A version bump is necessary in order to deprecate `get_day` function as it uses a deprecated `Chrono:: Date` function and structure; an alternative version is proposed that use `Chrono::NaiveDate`.

Also eliminates warning on `Cargo.toml` relatives to `package.maintenance` and `license-file`.

Finally as proposed by `cargo fix` unnecessary parentheses were removed.

Please review and provide feedback.